### PR TITLE
fix: corrige rutas PWA de /lumi-react/ a / para Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,13 @@
 {
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite",
   "routes": [
-    { "src": "/(.*)", "dest": "/" }
+    { "src": "/assets/(.*)", "dest": "/assets/$1" },
+    { "src": "/icons/(.*)", "dest": "/icons/$1" },
+    { "src": "/sw.js", "dest": "/sw.js" },
+    { "src": "/offline.html", "dest": "/offline.html" },
+    { "src": "/manifest.webmanifest", "dest": "/manifest.webmanifest" },
+    { "src": "/(.*)", "dest": "/index.html" }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       registerType: "autoUpdate",
 
       workbox: {
-        navigateFallback: "/lumi-react/index.html",
+        navigateFallback: "/index.html",
         globPatterns: ["**/*.{js,css,html,svg,png,jpg,jpeg,webp}"],
       },
 
@@ -33,8 +33,8 @@ export default defineConfig({
         short_name: "Lumi App",
         description:
           "Juegos de matemáticas, programación y ecología para niños, con Lumi.",
-        start_url: "/lumi-react/#/",
-        scope: "/lumi-react/",
+        start_url: "/",
+        scope: "/",
         display: "standalone",
         orientation: "landscape",
 


### PR DESCRIPTION
En [vite.config.ts](vite.config.ts) se corrigieron 3 rutas que todavía apuntaban a `/lumi-react/` (path de GitHub Pages), incompatibles con Vercel:

| `navigateFallback` | `/lumi-react/index.html` | `/index.html` |
| `start_url` | `/lumi-react/#/` | `/` |
| `scope` | `/lumi-react/` | `/` |

